### PR TITLE
docs: description is required when attach mode is `agent-requested`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Each rule Markdown file can have the following metadata in its frontmatter:
 | Key           | Type    | Required | Description                                                                                                |
 |---------------|---------|----------|------------------------------------------------------------------------------------------------------------|
 | `attach` | String  | Yes       | Situation you want AI to read this rule. <br> Choose from `always`, `glob`, `agent-requested`, `manual`.  |
-| `glob`      | Array  | Yes (when `attach` is `glob`)       | An array of glob patterns specifying which files this rule should apply to. <br> (e.g., `["**/*.go", "!**/*_test.go"]`). |
-| `description` | String  | No       | A brief description of what the prompt is for.                                                                |
+| `glob`      | Array  | Yes <br> (when `attach` is `glob`)       | An array of glob patterns specifying which files this rule should apply to. <br> (e.g., `["**/*.go", "!**/*_test.go"]`). |
+| `description` | String  | Yes <br> (when `attach` is `agent-requested`)       | A brief description of what the prompt is for.                                                                |
 
 Example `rules/my-custom-rule.md`:
 


### PR DESCRIPTION
closes #13 